### PR TITLE
make paragraph styles work

### DIFF
--- a/src/layout/generic_layout.ts
+++ b/src/layout/generic_layout.ts
@@ -172,7 +172,7 @@ export default class GenericLayout {
       debug('No text for placeholder %s');
       return;
     }
-
+    
     if (typeof placeholder === 'string') {
       assert(this.slide.objectId);
       const pageElements = findPlaceholder(

--- a/src/parser/extract_slides.ts
+++ b/src/parser/extract_slides.ts
@@ -176,6 +176,7 @@ inlineTokenRules['text'] = (token, context) => {
 };
 
 inlineTokenRules['paragraph_open'] = (token, context) => {
+  const style = applyTokenStyle(token, {});
   assert(context.currentSlide);
   if (hasClass(token, 'column')) {
     context.markerParagraph = true;
@@ -191,6 +192,7 @@ inlineTokenRules['paragraph_open'] = (token, context) => {
   } else if (!context.text) {
     context.startTextBlock();
   }
+  context.startStyle(style);
 
   const layout = attr(token, 'layout');
   // If we have a layout attribute set this on the slide so we can select the
@@ -207,6 +209,7 @@ inlineTokenRules['paragraph_close'] = (token, context) => {
   } else {
     context.appendText('\n');
   }
+  context.endStyle();
 };
 
 inlineTokenRules['fence'] = (token, context) => {


### PR DESCRIPTION
Looks like md2googleslides was parsing markdown attribute tokens on paragraph elements -- it just wasn't checking to see if they existed!